### PR TITLE
Fixing regex to only match input parameter

### DIFF
--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -13,7 +13,7 @@ module FFMPEG
 
       # codecs should go before the presets so that the files will be matched successfully
       # all other parameters go after so that we can override whatever is in the preset
-      input   = params.select { |p| p =~ /\-i/ }
+      input   = params.select { |p| p =~ /^\-i / }
       seek    = params.select {|p| p =~ /\-ss/ }
       codecs  = params.select { |p| p =~ /codec/ }
       presets = params.select { |p| p =~ /\-.pre/ }
@@ -154,7 +154,7 @@ module FFMPEG
         "-filter_complex 'scale=#{self[:resolution]},overlay=x=#{value[:padding_x]}:y=main_h-overlay_h-#{value[:padding_y]}'"
       when "RB"
         "-filter_complex 'scale=#{self[:resolution]},overlay=x=main_w-overlay_w-#{value[:padding_x]}:y=main_h-overlay_h-#{value[:padding_y]}'"
-      end  
+      end
     end
 
     def convert_custom(value)

--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -132,6 +132,11 @@ module FFMPEG
         converted.should == "-vcodec libx264 -vpre normal -r 25"
       end
 
+      it "correctly identifies the input parameter" do
+        converted = EncodingOptions.new({ input: 'somefile.mp4', custom: '-pass 1 passlogfile bla-i-bla' }).to_s
+        converted.should == "-i somefile.mp4 -pass 1 passlogfile bla-i-bla"
+      end
+
       it "should convert a lot of them simultaneously" do
         converted = EncodingOptions.new(video_codec: "libx264", audio_codec: "aac", video_bitrate: "1000k").to_s
         converted.should match(/-acodec aac/)


### PR DESCRIPTION
Other parameters that included `-i` had the potential to be misinterpreted as the input parameter (see the spec for an example).
