### PR TITLE
Include color metadata

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -6,6 +6,7 @@ module FFMPEG
     attr_reader :path, :duration, :time, :bitrate, :rotation, :creation_time
     attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :frame_rate, :has_b_frames, :video_profile, :video_level
     attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags
+    attr_reader :color_primaries, :avframe_color_space, :color_transfer
     attr_reader :container
     attr_reader :error
 
@@ -57,6 +58,9 @@ module FFMPEG
           video_stream = video_streams.first
           @video_codec = video_stream[:codec_name]
           @colorspace = video_stream[:pix_fmt]
+          @color_primaries = video_stream[:color_primaries]
+          @avframe_color_space = video_stream[:color_space]
+          @color_transfer = video_stream[:color_transfer]
           @width = video_stream[:width]
           @height = video_stream[:height]
           @video_bitrate = video_stream[:bit_rate].to_i


### PR DESCRIPTION
Makes more color metadata available in `Movie` instances. Had to use the name `avframe_color_space` as the gem already used `@colorspace = video_stream[:pix_fmt]`.